### PR TITLE
Fixed args for suggested formatter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ You can also use diagnostic [diagnostic-language-server](https://github.com/iamc
 "diagnostic-languageserver.formatters": {
   "black": {
     "command": "black",
-    "args": ["black", "-q", "-"]
+    "args": ["-q", "-"]
   },
   "isort": {
     "command": "isort",


### PR DESCRIPTION
The args for black were wrong, starting with black itself, so the config wouldn't work.