### PR TITLE
Change "activationEvents" to when the Python file is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^3.3.11"
   },
   "activationEvents": [
-    "*"
+    "onLanguage:python"
   ],
   "contributes": {
     "configuration": {


### PR DESCRIPTION
## Description

The current `"activationEvents"` is set to `"*"`.

I changed it to `"onLanguage:python"` because I thought it would behave better if coc-jedi was loaded when the Python file was opened.

## Note

If you have intentionally set `"*"`, please close this PR. 🙇