### PR TITLE
Added missing ',' to json in README under Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following is a snippet of `coc-settings.json` with defaults or with acceptab
   "jedi.diagnostics.didChange": true,
   "jedi.diagnostics.didSave": true,
   "jedi.workspace.extraPaths": [],
-  "jedi.workspace.symbols.maxSymbols": 20
+  "jedi.workspace.symbols.maxSymbols": 20,
   "jedi.workspace.symbols.ignoreFolders": [".nox", ".tox", ".venv", "__pycache__", "venv"]
 }
 ```


### PR DESCRIPTION
Title says it all. There was a comma missing in this JSON, this change should make it easier to copy/paste directly into `coc-settings.json` and get back to writing python!