### PR TITLE
Remove system-site-packages option when creating venv

### DIFF
--- a/src/jlsExecutable.ts
+++ b/src/jlsExecutable.ts
@@ -44,7 +44,7 @@ function createJlsVenvPosix(): string {
     try {
       execSync(
         'python3 -m venv ' +
-          `--system-site-packages --clear ${pathVenv} && ` +
+          `--clear ${pathVenv} && ` +
           `${pathPip} install -U pip ${JLS_NAME}==${JLS_VERSION}`
       )
       window.showMessage(`jedi: installed ${JLS_NAME}==${JLS_VERSION}`)


### PR DESCRIPTION
Having this option installs the JLS on the system Python bin path,
instead of <venv>/bin path.

This commit resolves #48